### PR TITLE
Add ARB importer

### DIFF
--- a/po2strings/__init__.py
+++ b/po2strings/__init__.py
@@ -9,5 +9,5 @@
     :license: MIT, see LICENSE for more details.
 """
 
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 __version__ = VERSION

--- a/po2strings/importers/arb.py
+++ b/po2strings/importers/arb.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+
+import os
+import json
+import re
+
+class ArbImporter:
+    def __init__(self, matches, strings_file):
+        self.matches = matches
+        self.destination_file = strings_file
+    
+    def clean_string(self, string):
+        s = string.replace("%d", "%s")
+        s = s.replace("%f", "%s")
+        return s
+
+    def clean_placeholders(self, string, placeholders):
+        for placeholder in placeholders:
+            string = string.replace("{%s}" % placeholder, "%s")
+        return string
+    
+    def get_ordered_placeholders(self, string):
+        placeholder_pattern = r"{([a-zA-Z0-9_]+)}"
+        return re.findall(placeholder_pattern, string)
+
+    def split_plural_string(self, plural_string, plural_placeholder, placeholders):
+        # init output array
+        split_strings = []
+
+        # this pattern finds if the string contains plurals
+        pattern = r"^{"+ plural_placeholder +",plural, (?P<imploded_string>.*)}"
+        prog = re.compile(pattern)
+
+        # if there is no plural match, just return
+        match = prog.match(plural_string)
+        if not match:
+            return []
+
+        # get the group of plural strings, e.g.
+        #  =0{string value}=1{string value}other{string value}
+        imploded_string = match.groupdict()['imploded_string']
+
+        # safely remove {placeholders} to avoid replace in the following loop
+        for placeholder in placeholders:
+            imploded_string = imploded_string.replace("{%s}" % placeholder, "_#|%s|#_" % placeholder)
+
+        # consume the string to get all the plural cases
+        while imploded_string != '':
+            # get position of first { char and first } char,
+            # we'll then be sure that the content is a string value for a plural case
+            entry = imploded_string[imploded_string.find('{')+1:imploded_string.find('}')]
+
+            # restore placeholders in the {placeholder} format
+            for placeholder in placeholders:
+                entry = entry.replace("_#|%s|#_" % placeholder, "{%s}" % placeholder)
+
+            # get ordered placeholders
+            ordered_placeholders = self.get_ordered_placeholders(entry)
+            
+            # append the entry to the output array
+            split_strings.append({
+                'plural_case': imploded_string[:imploded_string.find('{')],
+                'string': entry,
+                'ordered_placeholders': ordered_placeholders
+            })
+
+            # go to the next case, if it does exist
+            imploded_string = imploded_string[imploded_string.find('}')+1:]
+
+        return split_strings
+
+    def run(self):
+        # check if the destination file exists,
+        # as it will be replaced by the translated version of itself
+        if not os.path.isfile(self.destination_file):
+            raise Exception("Destination arb file %s doesn't exist" % (self.destination_file))
+
+        # open the arb file and convert it to a dictionary
+        # using json.load (arb is JSON in fact), then close the file
+        with open(self.destination_file, 'r') as arb_file:
+            arb_file_as_dict = json.load(arb_file)
+            arb_file.close()
+
+        # cycle the arb dictionary
+        for key in arb_file_as_dict:
+            # keys with @ prefix hold the placeholders,
+            # keys without it hold the string
+
+            placeholders = []
+            if key[0] == '@':
+                # get placeholders for current key
+                for placeholder in arb_file_as_dict[key]['placeholders']:
+                    placeholders.append(placeholder)
+
+                # get string...
+                source_string = arb_file_as_dict[key[1:]]
+
+                # on plural strings, we'll split the string into multiple
+                # entries, because they are stored separately into the PO
+                # translations file
+
+                # set if it is singular case
+                strings_to_parse_for_key = [{
+                    'plural_case': 'single',
+                    'string': source_string,
+                    'ordered_placeholders': self.get_ordered_placeholders(source_string)
+                }]
+                plural = False
+                plural_placeholder = None
+
+                # now check if plural
+                for placeholder in placeholders:
+                    if "{%s,plural" % placeholder in source_string:
+                        strings_to_parse_for_key = self.split_plural_string(source_string, placeholder, placeholders)
+                        plural_placeholder = placeholder
+                        plural = True
+                        break
+
+                # prepare an empty array of strings found in PO file
+                strings_found_in_po = []
+
+                # for each string to parse for current key
+                for each_string_to_parse in strings_to_parse_for_key:
+                    untraslated_string = self.clean_placeholders(
+                        each_string_to_parse['string'],
+                        placeholders
+                    )
+
+                    # search for matches in translated PO file
+                    for m in self.matches:
+                        translated_string_id = self.clean_string(m['id'])
+
+                        # if they do match, we can put the translated string
+                        # into arb_file_as_dict[key[1:]]
+                        if translated_string_id == untraslated_string:
+                            each_string_to_parse['string'] = self.clean_string(m['string'])
+                            strings_found_in_po.append(each_string_to_parse)
+
+                # if the string is not plural we can just restore
+                # its ordered placeholders
+                if not plural:
+                    translation = strings_found_in_po[0]['string']
+                    for placeholder in strings_found_in_po[0]['ordered_placeholders']:
+                        translation = translation.replace('%s', "{%s}" % placeholder, 1)
+                
+                # if it is plural, we have to rejoin the plural string
+                # according to the specific format
+                else:
+                    translation = ''
+                    for string_entry in strings_found_in_po:
+                        for placeholder in string_entry['ordered_placeholders']:
+                            string_entry['string'] = string_entry['string'].replace('%s', "{%s}" % placeholder, 1)
+                        translation += "%s{%s}" % (string_entry['plural_case'], string_entry['string'])
+                    
+                    translation = "%s,plural, %s}" % (
+                        source_string[:source_string.find(',plural, ')],
+                        translation
+                    )
+                
+                # eventually, we replace the original string with its translation
+                arb_file_as_dict[key[1:]] = translation
+        
+        # save the arb_file_as_dict as self.destination_file
+        with open(self.destination_file, 'w+') as sf:
+            json.dump(arb_file_as_dict, sf)
+            sf.close()

--- a/po2strings/importers/arb_test.py
+++ b/po2strings/importers/arb_test.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+import arb
+import json
+
+class ArbImporterTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_matches = [
+            {
+                "context": "CONTEXT1",
+                "id": "Dear \"%s\",\nyou are visitor number %d!",
+                "string": "Caro \"%s\",\nsei il visitatore numero %d!"
+            },
+            {
+                "context": "CONTEXT2",
+                "id": "Your cart is empty",
+                "string": "Il tuo carrello non contiene oggetti"
+            },
+            {
+                "context": "CONTEXT3",
+                "id": "Your cart contains 1 item",
+                "string": "Il tuo carrello contiene un oggetto"
+            },
+            {
+                "context": "CONTEXT4",
+                "id": "Your cart contains %d items",
+                "string": "Il tuo carrello contiene %d oggetti"
+            }
+        ]
+        self.mock_destination_file = 'mock_destination_arb.arb'
+
+        with open(self.mock_destination_file, 'w') as arb_file:
+            mock_arb_file = '''{
+    "visitorCounterMessage": "Dear \\"{visitorName}\\",\\nyou are visitor number {visitorNumber}!",
+    "@visitorCounterMessage": {
+        "type": "text",
+        "placeholders": {
+            "visitorName": {},
+            "visitorNumber": {}
+        }
+    },
+    "cartMessage": "{itemCounter,plural, =0{Your cart is empty}=1{Your cart contains 1 item}other{Your cart contains {itemCounter} items}}",
+    "@cartMessage": {
+        "type": "text",
+        "placeholders": {
+            "itemCounter": {}
+        }
+    }
+}'''
+            arb_file.write(mock_arb_file)
+            arb_file.close()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.mock_destination_file)
+        except Exception, e:
+            pass
+
+    # test that the ArbImporter class constructor sets matches and destination_file attributes
+    def test_ctor(self):
+        sut = arb.ArbImporter(
+            self.mock_matches,
+            self.mock_destination_file
+        )
+
+        self.assertEqual(sut.matches, self.mock_matches)
+        self.assertEqual(sut.destination_file, self.mock_destination_file)
+
+    # test that ArbImporter split_plural_string method splits plural string in multiple strings
+    def test_split_plural_strings(self):
+        sut = arb.ArbImporter('', '')
+
+        mock_multiple_string = "{howMany,plural, =0{Dear {customerName}, your cart is empty}=1{Dear {customerName}, you''ve one item in your cart}other{Dear {customerName}, you have {howMany} items in your chart}}"
+        self.assertEqual(
+            sut.split_plural_string(
+                mock_multiple_string,
+                'howMany',
+                ['howMany', 'customerName']
+            ),
+            [
+                {
+                    'plural_case': '=0',
+                    'string': "Dear {customerName}, your cart is empty", 
+                    'ordered_placeholders': ['customerName']
+                },
+                {
+                    'plural_case': '=1',
+                    'string': "Dear {customerName}, you''ve one item in your cart", 
+                    'ordered_placeholders': ['customerName']
+                },
+                {
+                    'plural_case': 'other',
+                    'string': "Dear {customerName}, you have {howMany} items in your chart", 
+                    'ordered_placeholders': ['customerName', 'howMany']
+                }
+            ]
+        )
+    
+    # test that ArbImporter class clean_string method transforms any placeholder into %s 
+    def test_clean_string(self):
+        sut = arb.ArbImporter('', '')
+
+        mock_string = "Hello %s, you are visitor number %d on site %s having score %f"
+        self.assertEqual(
+            sut.clean_string(mock_string),
+            "Hello %s, you are visitor number %s on site %s having score %s"
+        )
+
+    # test that ArbImporter class clean_placeholders method strips {placeholders} from string
+    # converting them to %s placeholders 
+    def test_clean_placeholders(self):
+        sut = arb.ArbImporter('', '')
+
+        mock_string = "Hello {visitorName}, you are visitor number {visitorNumber}"
+        mock_placeholders = ['visitorName', 'visitorNumber']
+        self.assertEqual(
+            sut.clean_placeholders(mock_string, mock_placeholders),
+            "Hello %s, you are visitor number %s"
+        )
+    
+    # test that ArbImporter class get_ordered_placeholders method returns an 
+    # ordered array of strings containing {placeholders} in the input string
+    def test_get_ordered_placeholders(self):
+        sut = arb.ArbImporter('', '')
+
+        mock_string = "This string contains {placeholder1}, {placeholder2} and {placeholder3}"
+        self.assertEqual(
+            sut.get_ordered_placeholders(mock_string),
+            ['placeholder1', 'placeholder2', 'placeholder3']
+        )
+
+    # test that ArbImporter class run creates a .strings file containing input matches
+    def test_run(self):
+        sut = arb.ArbImporter(
+            self.mock_matches,
+            self.mock_destination_file
+        )
+
+        mock_output_arb_file = json.loads('''{
+    "visitorCounterMessage": "Caro \\"{visitorName}\\",\\nsei il visitatore numero {visitorNumber}!",
+    "@visitorCounterMessage": {
+        "type": "text",
+        "placeholders": {
+            "visitorName": {},
+            "visitorNumber": {}
+        }
+    },
+    "cartMessage": "{itemCounter,plural, =0{Il tuo carrello non contiene oggetti}=1{Il tuo carrello contiene un oggetto}other{Il tuo carrello contiene {itemCounter} oggetti}}",
+    "@cartMessage": {
+        "type": "text",
+        "placeholders": {
+            "itemCounter": {}
+        }
+    }
+}''')
+
+        sut.run()
+
+        with open(self.mock_destination_file, 'r') as arb_file:
+            built_file = json.load(arb_file)
+            arb_file.close() 
+
+        self.assertEqual(
+            built_file,
+            mock_output_arb_file
+        )

--- a/po2strings/po2strings.py
+++ b/po2strings/po2strings.py
@@ -7,7 +7,7 @@ import time
 import datetime
 import hashlib
 
-from importers import android, ios
+from importers import android, ios, arb
 
 class Po2StringsConverter:
     importer = None
@@ -25,6 +25,8 @@ class Po2StringsConverter:
             self.importer = android.AndroidImporter(matches, strings_file)
         elif os.path.splitext(strings_file)[1] == ".strings":
             self.importer = ios.iOSImporter(matches, strings_file)
+        elif os.path.splitext(strings_file)[1] == ".arb":
+            self.importer = arb.ArbImporter(matches, strings_file)
         else:
             raise Exception("Strings file format not supported for file %s" % (strings_file))
 


### PR DESCRIPTION
This branch adds an importer for [application resource bundle translation files](https://github.com/googlei18n/app-resource-bundle).

Please verify that the script is still working fine by writing a it.po file such as:

```po
msgid ""
msgstr ""
"Project-Id-Version: \n"
"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
"POT-Creation-Date: 2016-11-15 15:27\n"
"PO-Revision-Date: 2016-10-19 10:52+0200\n"
"Last-Translator: Tester <tester@email.address>\n"
"Language-Team: Italian <http://address>\n"
"Language: it\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=n != 1;\n"
"X-Generator: Weblate 2.2\n"
"X-Poedit-Basepath: .\n"

#: source.file:2
msgctxt "K99b6b_A_SNEAK_PEEK_OF_THE_NEW_09e2c"
msgid "A sneak peek of the new %s"
msgstr "Un'anteprima del nuovo %s"

#: source.file:4
msgctxt "Kc4408_ACCEPT_d3350"
msgid "Accept"
msgstr "Accetta"

```

Launch `python po2strings.py it.po it.arb`: IT SHOULD FAIL WITH THE `Destination arb file it.arb doesn't exist` error.

Then create an `it.arb` file as follows:

```json
{
	"sneakPeekMessage": "A sneak peek of the new {platformName}",
	"@sneakPeekMessage": {
		"type": "text",
		"placeholders": {
			"platformName": {}
		}
	},
	"acceptMessage": "Accept",
	"@acceptMessage": {
		"type": "text",
		"placeholders": {}
	}
}
```

And run the command again. It should output "OK". Verify the it.arb file again, as it should now contain translated strings.