### PR TITLE
Return sys exit on exceptions

### DIFF
--- a/po2strings/__init__.py
+++ b/po2strings/__init__.py
@@ -9,5 +9,5 @@
     :license: MIT, see LICENSE for more details.
 """
 
-VERSION = '0.3.5'
+VERSION = '0.3.6'
 __version__ = VERSION

--- a/po2strings/po2strings.py
+++ b/po2strings/po2strings.py
@@ -122,6 +122,7 @@ def main():
             print "OK"
         except Exception, e:
             print e
+            sys.exit(1)
     else:
         _usage()
 


### PR DESCRIPTION
[Storia di riferimento](https://www.pivotaltracker.com/story/show/151165148)

Questa PR modifica il comportamento a po2strings per restituire un errore al sistema quando si verificano eccezioni. Fino ad oggi infatti l'errore veniva solo stampato.

Verificare il codice.
